### PR TITLE
Fix syntax in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ bundle exec jekyll s
 </div>
 
 
+<!-- TABLE OF CONTENTS -->
+<details>
+  <summary>Table of Contents</summary>
+  <ol>
+    <li><a href="#tech-stack">Tech Stack</a></li>
+    <li><a href="#folder-structure">Folder Structure</a></li>
+    <li><a href="#acknowledgments">Acknowledgments</a></li>
+  </ol>
+</details>
+
 ## Tech Stack
 [![Ruby][Ruby]][ruby-url] [![HTML5][HTML]][ruby-url]
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -93,6 +103,20 @@ Place to store all static assets.</br>
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
+
+<!-- ACKNOWLEDGMENTS -->
+## Acknowledgments
+
+List of resources for inspiration and guide you into a direction:
+
+* [Choose an Open Source License](https://choosealicense.com)
+* [GitHub Emoji Cheat Sheet](https://www.webpagefx.com/tools/emoji-cheat-sheet)
+* [Badges](https://github.com/Envoy-VC/awesome-badges)
+* [Jekyll](https://jekyllrb.com/)
+
+<!--* []() -->
+
+<p align="right">(<a href="#readme-top">back to top</a>)</p>
 
 
 <!-- MARKDOWN LINKS & IMAGES

--- a/_posts/2024-06-12-test-1.md
+++ b/_posts/2024-06-12-test-1.md
@@ -2,7 +2,7 @@
 title: Test 1 - Lorem Welcome
 date: 2024-06-12 12:00:00 -500
 categories: [random,new]
-tags: [technology,random,science]     # TAG names should always be lowercase
+tags: [technology,random,skience]     # TAG names should always be lowercase
 image: "https://i.pinimg.com/originals/93/f8/9b/93f89b965b719a175e2ac7de6c3e8b54.gif"
 ---
 
@@ -25,11 +25,11 @@ Often times, welcoming is rarely used. Lorem ipsum dolor sit amet consectetur, a
 
 ## Secret Art Gallery
 
-| a      | b      | c          |
-|:-------|:-------|:-----------|
-|<img src="https://media1.tenor.com/m/sgbDzFuBsG0AAAAd/lebron-jam.gif" width="250" height="250"/>  |<img src="https://media1.tenor.com/m/sgbDzFuBsG0AAAAd/lebron-jam.gif" width="250" height="250"/>  |<img src="https://media1.tenor.com/m/sgbDzFuBsG0AAAAd/lebron-jam.gif" width="250" height="250"/>  |
-|<img src="https://media1.tenor.com/m/-d4FrVwQg6EAAAAC/blinking-guy.gif" width="250" height="250"/> |<img src="https://media1.tenor.com/m/-d4FrVwQg6EAAAAC/blinking-guy.gif" width="250" height="250"/>   |<img src="https://media1.tenor.com/m/-d4FrVwQg6EAAAAC/blinking-guy.gif" width="250" height="250"/>  |
-|<img src="https://media1.tenor.com/m/x8v1oNUOmg4AAAAd/rickroll-roll.gif" width="250" height="250"/>   |<img src="https://media1.tenor.com/m/x8v1oNUOmg4AAAAd/rickroll-roll.gif" width="250" height="250"/>   |<img src="https://media1.tenor.com/m/x8v1oNUOmg4AAAAd/rickroll-roll.gif" width="250" height="250"/>   |
-
+| Test A      | Test B      | Test C     |
+|:------------|:------------|:-----------|
+|<img src="https://c.tenor.com/sgbDzFuBsG0AAAAd/tenor.gif" alt='lebron-jam-gif' width="250" height="250"/>  |<img src="https://c.tenor.com/sgbDzFuBsG0AAAAd/tenor.gif" alt='lebron-jam-gif' width="250" height="250"/>  |<img src="https://c.tenor.com/sgbDzFuBsG0AAAAd/tenor.gif" alt='lebron-jam-gif' width="250" height="250"/>  |
+|<img src="https://c.tenor.com/-d4FrVwQg6EAAAAC/tenor.gif" alt='drew-scanlon-blinking' width="250" height="250"/>  |<img src="https://c.tenor.com/-d4FrVwQg6EAAAAC/tenor.gif" alt='drew-scanlon-blinking' width="250" height="250"/>  |<img src="https://c.tenor.com/-d4FrVwQg6EAAAAC/tenor.gif" alt='drew-scanlon-blinking' width="250" height="250"/>  |
+|<img src="https://c.tenor.com/x8v1oNUOmg4AAAAd/tenor.gif" alt='rick-astley-dancing' width="250" height="250"/>  |<img src="https://c.tenor.com/x8v1oNUOmg4AAAAd/tenor.gif" alt='rick-astley-dancing' width="250" height="250"/>  |<img src="https://c.tenor.com/x8v1oNUOmg4AAAAd/tenor.gif" alt='rick-astley-dancing' width="250" height="250"/>  |
+Pushing the boundaries </br> of test in markdown. 🫸 |Is this good content </br> for a blog? 🤔 |Feeling happy </br> just because 🤗 |
 
 

--- a/_posts/2024-06-25-test-3.md
+++ b/_posts/2024-06-25-test-3.md
@@ -18,7 +18,7 @@ In the light of delight, one should not have any shred of pessimism. Such an att
 
 * Text isn't necessarily the most effective form of communication due to:
 1. Lack of discernible tone detection
-2. Being inaccessible to those with visual impairments
+2. Being inaccessible to those with visual impairments 🙈
 
 ## Table for Thee
 


### PR DESCRIPTION
<b>Description:</b>
Github pages was not able to build due to failed images check

<hr>

<b>Fix:</b>
- Changed the img src to links that were the gif itself. The initial links were links to the website that contained the gif
- Added missing alt attributes for html-proofer validation

<hr>

<b>Pictures:</b>
![build-error-1](https://github.com/WackyChomp/WackyChomp.github.io/assets/65786984/6264a644-28f7-4e64-93c0-11b05d43eba9)
![build-error-2](https://github.com/WackyChomp/WackyChomp.github.io/assets/65786984/c9ac88b2-e025-4d72-85dd-2a74efb16413)
![post-with-error](https://github.com/WackyChomp/WackyChomp.github.io/assets/65786984/94ea8b49-6bcf-40a0-95af-544d9bbd8d1f)

- <b>Clicking the images redirected to blank page with ``Non-Image content-type returned``</b>